### PR TITLE
[FEAT] 회원가입 API , 로그인 API 기능 구현

### DIFF
--- a/src/main/java/com/yonyk/talaria/auth/TalariaAuthApplication.java
+++ b/src/main/java/com/yonyk/talaria/auth/TalariaAuthApplication.java
@@ -2,7 +2,9 @@ package com.yonyk.talaria.auth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class TalariaAuthApplication {
 

--- a/src/main/java/com/yonyk/talaria/auth/common/anotation/ValidMemberName.java
+++ b/src/main/java/com/yonyk/talaria/auth/common/anotation/ValidMemberName.java
@@ -1,0 +1,22 @@
+package com.yonyk.talaria.auth.common.anotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import com.yonyk.talaria.auth.common.anotation.validator.MemberNameValidator;
+
+@Constraint(validatedBy = MemberNameValidator.class)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidMemberName {
+  String message() default "아이디를 다시 입력해주세요.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/yonyk/talaria/auth/common/anotation/ValidPassword.java
+++ b/src/main/java/com/yonyk/talaria/auth/common/anotation/ValidPassword.java
@@ -1,0 +1,23 @@
+package com.yonyk.talaria.auth.common.anotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import com.yonyk.talaria.auth.common.anotation.validator.PasswordValidator;
+
+// 비밀번호 검증을 위한 커스텀 어노테이션
+@Constraint(validatedBy = PasswordValidator.class)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPassword {
+  String message() default "비밀번호를 다시 입력해주세요.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/yonyk/talaria/auth/common/anotation/validator/MemberNameValidator.java
+++ b/src/main/java/com/yonyk/talaria/auth/common/anotation/validator/MemberNameValidator.java
@@ -1,0 +1,35 @@
+package com.yonyk.talaria.auth.common.anotation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import com.yonyk.talaria.auth.common.anotation.ValidMemberName;
+
+public class MemberNameValidator implements ConstraintValidator<ValidMemberName, String> {
+
+  // 아이디는 영문과 숫자만 포함 가능
+  private static final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]+$";
+
+  @Override
+  public boolean isValid(String memberName, ConstraintValidatorContext context) {
+
+    // 아이디가 8자 이상인지 확인
+    if (memberName.length() < 9) {
+      context
+          .buildConstraintViolationWithTemplate("아이디는 8자 이상이어야합니다.")
+          .addConstraintViolation()
+          .disableDefaultConstraintViolation();
+      return false;
+    }
+
+    // 아이디가 영문, 숫자로만 이루어져있는지 확인
+    if (!memberName.matches(PASSWORD_REGEX)) {
+      context
+          .buildConstraintViolationWithTemplate("아이디는 영문과 숫자로 이루어져있어야합니다.")
+          .addConstraintViolation()
+          .disableDefaultConstraintViolation();
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/yonyk/talaria/auth/common/anotation/validator/PasswordValidator.java
+++ b/src/main/java/com/yonyk/talaria/auth/common/anotation/validator/PasswordValidator.java
@@ -1,0 +1,36 @@
+package com.yonyk.talaria.auth.common.anotation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import com.yonyk.talaria.auth.common.anotation.ValidPassword;
+
+// @ValidPassword 어노테이션에서 사용될 비밀번호 검증 클래스
+public class PasswordValidator implements ConstraintValidator<ValidPassword, String> {
+
+  // 비밀번호가 10자 이상, 숫자, 문자, 특수문자가 두가지 이상 포함되는 정규식표현
+  private static final String PASSWORD_REGEX = "^(?!\\d+$)(?=.*[A-Za-z])(?=.*\\d|.*[\\W_]).{10,}$";
+
+  @Override
+  public boolean isValid(String password, ConstraintValidatorContext context) {
+
+    // 비밀번호가 10자 이상인지 체크
+    if (password.length() < 10) {
+      context
+          .buildConstraintViolationWithTemplate("비밀번호는 10자 이상이어야합니다.")
+          .addConstraintViolation()
+          .disableDefaultConstraintViolation();
+      return false;
+    }
+
+    // 비밀번호가 정규식표현에 부합하는지 체크
+    if (!password.matches(PASSWORD_REGEX)) {
+      context
+          .buildConstraintViolationWithTemplate("비밀번호는 숫자, 문자, 특수문자가 2가지 이상 포함되어야 합니다.")
+          .addConstraintViolation()
+          .disableDefaultConstraintViolation();
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/yonyk/talaria/auth/common/config/GrpcSecurityConfig.java
+++ b/src/main/java/com/yonyk/talaria/auth/common/config/GrpcSecurityConfig.java
@@ -4,13 +4,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.yonyk.talaria.auth.common.security.grpc.CustomGrpcAuthenticationReader;
+import com.yonyk.talaria.auth.common.security.util.JwtProvider;
 
+import lombok.RequiredArgsConstructor;
 import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReader;
 
 @Configuration
+@RequiredArgsConstructor
 public class GrpcSecurityConfig {
+
+  // jwt 관리 클래스
+  private final JwtProvider jwtProvider;
+
   @Bean
   public GrpcAuthenticationReader grpcAuthenticationReader() {
-    return new CustomGrpcAuthenticationReader();
+    return new CustomGrpcAuthenticationReader(jwtProvider);
   }
 }

--- a/src/main/java/com/yonyk/talaria/auth/common/security/details/PrincipalDetailsService.java
+++ b/src/main/java/com/yonyk/talaria/auth/common/security/details/PrincipalDetailsService.java
@@ -27,7 +27,7 @@ public class PrincipalDetailsService implements UserDetailsService {
             .orElseThrow(
                 () ->
                     new UsernameNotFoundException(
-                        SecurityExceptionType.USER_NOT_FOUND.getMessage()));
+                        SecurityExceptionType.MEMBER_NOT_FOUND.getMessage()));
     return new PrincipalDetails(member);
   }
 }

--- a/src/main/java/com/yonyk/talaria/auth/common/security/filter/AuthenticationFilter.java
+++ b/src/main/java/com/yonyk/talaria/auth/common/security/filter/AuthenticationFilter.java
@@ -8,7 +8,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -41,10 +40,6 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
   private final RefreshTokenRepository refreshTokenRepository;
   // 예외 처리
   private final SecurityExceptionHandler securityExceptionHandler;
-
-  // refreshToken 프리픽스
-  @Value("${spring.data.redis.prefix}")
-  String refreshTokenPrefix;
 
   // 클래스 생성 완료 후 초기화
   @PostConstruct
@@ -102,7 +97,7 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
   private void storeRefreshToken(Authentication authResult, JwtRecord jwtRecord) {
     long memberId = ((PrincipalDetails) authResult.getPrincipal()).getMemberId();
     refreshTokenRepository.save(
-        new RefreshToken(refreshTokenPrefix + jwtRecord.refreshToken(), String.valueOf(memberId)));
+        new RefreshToken(jwtRecord.refreshToken(), String.valueOf(memberId)));
   }
 
   // 로그인 인증 실패시 실행되는 메소드

--- a/src/main/java/com/yonyk/talaria/auth/common/security/filter/AuthenticationFilter.java
+++ b/src/main/java/com/yonyk/talaria/auth/common/security/filter/AuthenticationFilter.java
@@ -23,7 +23,7 @@ import com.yonyk.talaria.auth.common.security.redis.RefreshToken;
 import com.yonyk.talaria.auth.common.security.redis.RefreshTokenRepository;
 import com.yonyk.talaria.auth.common.security.util.CookieProvider;
 import com.yonyk.talaria.auth.common.security.util.JwtProvider;
-import com.yonyk.talaria.auth.controller.dto.LoginDTO;
+import com.yonyk.talaria.auth.controller.request.LoginDTO;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/yonyk/talaria/auth/common/security/grpc/CustomGrpcAuthenticationReader.java
+++ b/src/main/java/com/yonyk/talaria/auth/common/security/grpc/CustomGrpcAuthenticationReader.java
@@ -21,7 +21,7 @@ public class CustomGrpcAuthenticationReader implements GrpcAuthenticationReader 
   @Value("${jwt.access-token-header}")
   private String accessTokenHeader;
 
-  private JwtProvider jwtProvider;
+  private final JwtProvider jwtProvider;
 
   @Nullable
   @Override

--- a/src/main/java/com/yonyk/talaria/auth/common/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/yonyk/talaria/auth/common/security/handler/CustomLogoutHandler.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
@@ -28,10 +27,6 @@ public class CustomLogoutHandler implements LogoutHandler {
   private final CookieProvider cookieProvider;
   private final RefreshTokenRepository refreshTokenRepository;
   private final SecurityExceptionHandler securityExceptionHandler;
-
-  // refreshToken 프리픽스
-  @Value("${spring.data.redis.prefix}")
-  String refreshTokenPrefix;
 
   public CustomLogoutHandler(
       CookieProvider cookieProvider,
@@ -66,8 +61,7 @@ public class CustomLogoutHandler implements LogoutHandler {
   // redis에서 refreshToken 삭제하는 메소드
   private void deleteRefreshTokenInRedis(Cookie findCookie) {
     // redis에서 refreshToken 찾기
-    Optional<RefreshToken> refreshToken =
-        refreshTokenRepository.findById(refreshTokenPrefix + findCookie.getValue());
+    Optional<RefreshToken> refreshToken = refreshTokenRepository.findById(findCookie.getValue());
     if (refreshToken.isPresent()) {
       // redis에서 refreshToken 삭제
       refreshTokenRepository.delete(refreshToken.get());

--- a/src/main/java/com/yonyk/talaria/auth/controller/MemberController.java
+++ b/src/main/java/com/yonyk/talaria/auth/controller/MemberController.java
@@ -1,7 +1,14 @@
 package com.yonyk.talaria.auth.controller;
 
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.yonyk.talaria.auth.controller.request.RegisterDTO;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,4 +17,11 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
-public class MemberController {}
+public class MemberController {
+
+  // 회원가입 API
+  @PostMapping
+  public ResponseEntity<String> signUp(@Valid @RequestBody RegisterDTO registerDTO) {
+    return null;
+  }
+}

--- a/src/main/java/com/yonyk/talaria/auth/controller/MemberController.java
+++ b/src/main/java/com/yonyk/talaria/auth/controller/MemberController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.yonyk.talaria.auth.controller.request.RegisterDTO;
+import com.yonyk.talaria.auth.service.MemberService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,9 +20,15 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/members")
 public class MemberController {
 
+  private final MemberService memberService;
+
   // 회원가입 API
   @PostMapping
   public ResponseEntity<String> signUp(@Valid @RequestBody RegisterDTO registerDTO) {
-    return null;
+    // 중복검증
+    memberService.validMember(registerDTO);
+    // 실제 회원가입
+    memberService.signUp(registerDTO);
+    return ResponseEntity.ok("회원가입이 성공적으로 완료되었습니다.");
   }
 }

--- a/src/main/java/com/yonyk/talaria/auth/controller/dto/LoginDTO.java
+++ b/src/main/java/com/yonyk/talaria/auth/controller/dto/LoginDTO.java
@@ -1,3 +1,0 @@
-package com.yonyk.talaria.auth.controller.dto;
-
-public record LoginDTO(String memberName, String password) {}

--- a/src/main/java/com/yonyk/talaria/auth/controller/request/LoginDTO.java
+++ b/src/main/java/com/yonyk/talaria/auth/controller/request/LoginDTO.java
@@ -1,0 +1,7 @@
+package com.yonyk.talaria.auth.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginDTO(
+    @NotBlank(message = "아이디를 입력해주세요.") String memberName,
+    @NotBlank(message = "비밀번호를 입력해주세요.") String password) {}

--- a/src/main/java/com/yonyk/talaria/auth/controller/request/RegisterDTO.java
+++ b/src/main/java/com/yonyk/talaria/auth/controller/request/RegisterDTO.java
@@ -1,0 +1,24 @@
+package com.yonyk.talaria.auth.controller.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+import com.yonyk.talaria.auth.common.anotation.ValidMemberName;
+import com.yonyk.talaria.auth.common.anotation.ValidPassword;
+import com.yonyk.talaria.auth.entity.Member;
+import com.yonyk.talaria.auth.entity.enums.MemberRole;
+
+public record RegisterDTO(
+    @NotBlank(message = "아이디를 입력해주세요.") @ValidMemberName String memberName,
+    @NotBlank(message = "비밀번호를 입력해주세요.") @ValidPassword String password,
+    @NotBlank(message = "이메일을 입력해주세요.") @Email(message = "올바른 이메일 형식이 아닙니다.") String email) {
+
+  public Member toMember(String password) {
+    return Member.builder()
+        .memberName(this.memberName)
+        .password(password)
+        .email(this.email)
+        .memberRole(MemberRole.USER)
+        .build();
+  }
+}

--- a/src/main/java/com/yonyk/talaria/auth/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/yonyk/talaria/auth/exception/CustomExceptionHandler.java
@@ -44,14 +44,7 @@ public class CustomExceptionHandler {
 
     if (bindingResult.hasErrors()) {
       for (FieldError fieldError : bindingResult.getFieldErrors()) {
-        builder
-            .append("[")
-            .append(fieldError.getField())
-            .append("](은)는 ")
-            .append(fieldError.getDefaultMessage())
-            .append(" 입력된 값: [")
-            .append(fieldError.getRejectedValue())
-            .append("] ");
+        builder.append(fieldError.getDefaultMessage()).append(" ");
       }
     }
 

--- a/src/main/java/com/yonyk/talaria/auth/exception/exceptionType/RegisterExceptionType.java
+++ b/src/main/java/com/yonyk/talaria/auth/exception/exceptionType/RegisterExceptionType.java
@@ -1,0 +1,43 @@
+package com.yonyk.talaria.auth.exception.exceptionType;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum RegisterExceptionType implements ExceptionType {
+  // 409 Conflic
+  // 중복된 계정
+  DUPLICATED_MEMBER_NAME(HttpStatus.CONFLICT, "이미 사용 중인 계정입니다."),
+  // 중복된 이메일
+  DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+  // Redis에 이미 저장된 사용자 정보가 있을 때
+  EMAIL_ALREADY_IN_PROGRESS(
+      HttpStatus.CONFLICT, "이 이메일로 가입이 진행중입니다. 이메일 인증을 완료하거나 일정 시간 후에 다시 시도해주세요."),
+
+  // 400 Bad Request
+  // 저장된 코드가 없을 때
+  NOT_FOUND_CODE(HttpStatus.BAD_REQUEST, "가입승인 코드가 유효하지 않습니다. 다시 시도해주세요."),
+  // 저장된 임시 데이터가 없을 때
+  NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST, "가입 가능 기간이 만료되었습니다. 다시 가입을 시도해주세요."),
+
+  // 500 Internal Server Error
+  // 코드 발송한 이메일과 임시 저장된 이메일 데이터 불일치
+  DATA_CONSISTENCY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다. 다시 시도해주세요.");
+
+  private final HttpStatus status;
+  private final String message;
+
+  @Override
+  public HttpStatus status() {
+    return this.status;
+  }
+
+  @Override
+  public String message() {
+    return this.message;
+  }
+}

--- a/src/main/java/com/yonyk/talaria/auth/exception/exceptionType/SecurityExceptionType.java
+++ b/src/main/java/com/yonyk/talaria/auth/exception/exceptionType/SecurityExceptionType.java
@@ -18,7 +18,7 @@ public enum SecurityExceptionType implements ExceptionType {
   SERVER_ERROR(HttpStatus.UNAUTHORIZED, "서버에서 문제가 발생했습니다. 잠시 후 다시 시도해 주세요."),
 
   // 404 Not Found
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 아이디의 회원이 없습니다."),
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 아이디의 회원이 없습니다."),
 
   // 401 Unautorized
   // JwtAuthorizationFilter(jwt 토큰 검증 때 사용되는 인증필터) 오류

--- a/src/main/java/com/yonyk/talaria/auth/repository/MemberRepository.java
+++ b/src/main/java/com/yonyk/talaria/auth/repository/MemberRepository.java
@@ -9,4 +9,10 @@ import com.yonyk.talaria.auth.entity.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
   // 로그인 시 memberName으로 사용자 반환
   Optional<Member> findByMemberName(String memberName);
+
+  // 계정명 중복 검사
+  boolean existsByMemberName(String memberName);
+
+  // 이메일 중복 검사
+  boolean existsByEmail(String email);
 }

--- a/src/main/java/com/yonyk/talaria/auth/service/MemberService.java
+++ b/src/main/java/com/yonyk/talaria/auth/service/MemberService.java
@@ -1,0 +1,37 @@
+package com.yonyk.talaria.auth.service;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.yonyk.talaria.auth.controller.request.RegisterDTO;
+import com.yonyk.talaria.auth.exception.CustomException;
+import com.yonyk.talaria.auth.exception.exceptionType.RegisterExceptionType;
+import com.yonyk.talaria.auth.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+  private final MemberRepository memberRepository;
+  private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+  // 회원가입 정보 검증
+  public void validMember(RegisterDTO registerDTO) {
+    // 계정명 중복 검증
+    boolean existByMemberName = memberRepository.existsByMemberName(registerDTO.memberName());
+    // 이메일 중복 검증
+    boolean existByEmai = memberRepository.existsByEmail(registerDTO.email());
+
+    // 중복일 시 예외 발생
+    if (existByMemberName) throw new CustomException(RegisterExceptionType.DUPLICATED_MEMBER_NAME);
+    if (existByEmai) throw new CustomException(RegisterExceptionType.DUPLICATED_EMAIL);
+  }
+
+  // 회원가입
+  public void signUp(RegisterDTO registerDTO) {
+    String password = bCryptPasswordEncoder.encode(registerDTO.password());
+    memberRepository.save(registerDTO.toMember(password));
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,12 +28,10 @@ spring:
     redis:
       host: localhost
       port: 6379
-      prefix: 'Refresh:'
 
 jwt:
   prefix: 'Bearer '
   access-token-header: Authorization
-  refresh-token-header: AuthorizationRefresh
   secret: ${SECRET_KEY}
   access-token-TTL: 300
   refresh-token-TTL: 259200


### PR DESCRIPTION
## ⭐️ Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #8

## ⭐️ Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 회원가입 API 기능 구현
- 로그인 API는 기존 스프링 시큐리티 구현과정에서 완료됨

## ⭐️ Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
### 회원가입 성공

![회원가입 성공](https://github.com/user-attachments/assets/e9fc1e20-c877-450a-92b8-f2bbbbed268d)

### 회원가입 실패(계정명 중복)

![회원가입 실패-계정명 중복](https://github.com/user-attachments/assets/5f05aae6-f1fa-4217-a18d-06a23a047b34)

### 회원가입 실패(이메일명 중복)

![회원가입 실패-이메일 중복](https://github.com/user-attachments/assets/eed2af65-2891-48e2-8b2d-43c78def3e4e)

### 회원가입 실패(계정명 8자 미만)

![회원가입 실패-계정명 8자 미만](https://github.com/user-attachments/assets/6fff1c64-b15e-4cd2-b25c-69121d7e4f33)

### 회원가입 실패(계정명 정규식 부적합)

![회원가입 실패-계정명 정규식 부적합](https://github.com/user-attachments/assets/dde7da5a-805b-4b4f-8eed-d3fdde61d671)

### 회원가입 실패(비밀번호 10자 미만)

![회원가입 실패-비밀번호 10자 미만](https://github.com/user-attachments/assets/34dc023e-b96f-4951-8407-1baaa5fd0a1c)

### 회원가입 실패(비밀번호 정규식 부적합)

![회원가입 실패-비밀번호 정규식 부적합](https://github.com/user-attachments/assets/a65fed22-7c0f-4f21-8cd7-1925d5153c06)

## ⭐️ To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
- 