### PR TITLE
[FEAT] refreshToken 재발급 API 기능 구현

### DIFF
--- a/src/main/java/com/yonyk/talaria/auth/common/config/SpringSecurityConfig.java
+++ b/src/main/java/com/yonyk/talaria/auth/common/config/SpringSecurityConfig.java
@@ -119,7 +119,7 @@ public class SpringSecurityConfig {
                 authz
                     // 회원가입, 로그인, 액세스 토큰 재발급
                     .requestMatchers(
-                        "/api/members", "/api/members/login", "/api/members/refresh_token")
+                        "/api/members", "/api/members/login", "/api/members/refresh-token")
                     .permitAll()
                     // 이외 모든 요청 인증 필요
                     .anyRequest()

--- a/src/main/java/com/yonyk/talaria/auth/controller/MemberController.java
+++ b/src/main/java/com/yonyk/talaria/auth/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.yonyk.talaria.auth.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -30,5 +32,13 @@ public class MemberController {
     // 실제 회원가입
     memberService.signUp(registerDTO);
     return ResponseEntity.ok("회원가입이 성공적으로 완료되었습니다.");
+  }
+
+  // 리프레시 토큰으로 엑세스 토큰, 리프레시 토큰 재발급
+  @PostMapping("/refresh-token")
+  public ResponseEntity<String> reissueRefreshToken(
+      HttpServletRequest request, HttpServletResponse response) {
+    memberService.reissueRefreshToken(request, response);
+    return ResponseEntity.ok("토큰 재발급이 성공적으로 완료되었습니다.");
   }
 }

--- a/src/main/java/com/yonyk/talaria/auth/service/JwtService.java
+++ b/src/main/java/com/yonyk/talaria/auth/service/JwtService.java
@@ -1,0 +1,101 @@
+package com.yonyk.talaria.auth.service;
+
+import java.util.Optional;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Service;
+
+import com.yonyk.talaria.auth.common.security.record.JwtRecord;
+import com.yonyk.talaria.auth.common.security.redis.RefreshToken;
+import com.yonyk.talaria.auth.common.security.redis.RefreshTokenRepository;
+import com.yonyk.talaria.auth.common.security.util.CookieProvider;
+import com.yonyk.talaria.auth.common.security.util.JwtProvider;
+import com.yonyk.talaria.auth.entity.Member;
+import com.yonyk.talaria.auth.exception.CustomException;
+import com.yonyk.talaria.auth.exception.exceptionType.SecurityExceptionType;
+import com.yonyk.talaria.auth.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+  // jwt 관리 클래스
+  private final JwtProvider jwtProvider;
+  // 쿠키 관리 클래스
+  private final CookieProvider cookieProvider;
+  // redis 리포지토리
+  private final RefreshTokenRepository refreshTokenRepository;
+  // Member 리포지토리
+  private final MemberRepository memberRepository;
+
+  // 엑세스 토큰, 리프레시 토큰 재발급
+  public void reissueRefreshToken(HttpServletRequest request, HttpServletResponse response) {
+    // 리퀘스트에서 refreshToken 쿠키 빼오기
+    Optional<Cookie> findCookie = getCookie(request);
+
+    // redis에서 쿠키 값을 이용해 refreshToken 가져오기
+    Optional<RefreshToken> refreshToken = getRefreshToken(findCookie);
+
+    // DB에서 Member 객체 가져오기
+    Member findMember = getMember(refreshToken.get().getMemberName());
+
+    // 토큰 재발급 후 헤더, 쿠키, redis에 토큰 저장
+    reissueToken(findMember, response);
+  }
+
+  // 리퀘스트에서 refreshToken 빼오기
+  private Optional<Cookie> getCookie(HttpServletRequest request) {
+    Optional<Cookie> findCookie = cookieProvider.getRefreshTokenCookie(request);
+    if (!findCookie.isPresent()) {
+      log.error("JwtService 오류: " + SecurityExceptionType.COOKIE_NOT_FOUND.getMessage());
+      throw new CustomException(SecurityExceptionType.COOKIE_NOT_FOUND);
+    }
+    return findCookie;
+  }
+
+  // redis에서 쿠키 값을 이용해 refreshToken 가져오기
+  private Optional<RefreshToken> getRefreshToken(Optional<Cookie> findCookie) {
+    String refreshToken = findCookie.get().getValue();
+    Optional<RefreshToken> findRefreshToken = refreshTokenRepository.findById(refreshToken);
+    if (!findRefreshToken.isPresent()) {
+      log.error("JwtService 오류: " + SecurityExceptionType.REFRESHTOKEN_NOT_FOUND.getMessage());
+      throw new CustomException(SecurityExceptionType.REFRESHTOKEN_NOT_FOUND);
+    }
+    refreshTokenRepository.deleteById(refreshToken);
+    return findRefreshToken;
+  }
+
+  // Member 객체 가져오기
+  private Member getMember(String memberId) {
+    // 계정 아이디 찾아오기
+    long savedMemberId = Long.parseLong(memberId);
+
+    // memberRepository 에서 사용자 정보 가져오기
+    Member findMember =
+        memberRepository
+            .findById(savedMemberId)
+            .orElseThrow(() -> new CustomException(SecurityExceptionType.MEMBER_NOT_FOUND));
+    return findMember;
+  }
+
+  // 토큰 재발급
+  private void reissueToken(Member findMember, HttpServletResponse response) {
+    // 사용자 정보로 리프레시 토큰, 엑세스 토큰 다시 만들기
+    JwtRecord reissueToken = jwtProvider.getReissueToken(findMember);
+
+    // accessToken은 헤더에 저장
+    response.setHeader(
+        jwtProvider.accessTokenHeader, jwtProvider.prefix + reissueToken.accessToken());
+    // refreshToken은 쿠키에 저장
+    response.addCookie(cookieProvider.createRefreshTokenCookie(reissueToken.refreshToken()));
+    // redis에 refreshToken 저장, memberId는 String으로 변환 후 저장
+    refreshTokenRepository.save(
+        new RefreshToken(reissueToken.refreshToken(), String.valueOf(findMember.getMemberId())));
+  }
+}

--- a/src/main/java/com/yonyk/talaria/auth/service/MemberService.java
+++ b/src/main/java/com/yonyk/talaria/auth/service/MemberService.java
@@ -1,5 +1,8 @@
 package com.yonyk.talaria.auth.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +19,7 @@ public class MemberService {
 
   private final MemberRepository memberRepository;
   private final BCryptPasswordEncoder bCryptPasswordEncoder;
+  private final JwtService jwtService;
 
   // 회원가입 정보 검증
   public void validMember(RegisterDTO registerDTO) {
@@ -33,5 +37,10 @@ public class MemberService {
   public void signUp(RegisterDTO registerDTO) {
     String password = bCryptPasswordEncoder.encode(registerDTO.password());
     memberRepository.save(registerDTO.toMember(password));
+  }
+
+  // 리프레시 토큰으로 액세스 토큰, 리프레시 토큰 재발급
+  public void reissueRefreshToken(HttpServletRequest request, HttpServletResponse response) {
+    jwtService.reissueRefreshToken(request, response);
   }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #10 
## ⭐️ Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- refreshToken 재발급 API 기능 구현

## ⭐️ Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
### refreshToken 재발급 전

![리프레시 토큰 재발급 전](https://github.com/user-attachments/assets/4c3c9348-c1f8-4d82-9447-9facfb8387c9)

### refreshToken 재발급 전(레디스)

![리프레시 토큰 재발급 전 레디스](https://github.com/user-attachments/assets/383ee284-e928-4012-9491-2679dcf77685)

### refreshToken 재발급 후

![리프레시 토큰 재발급 후](https://github.com/user-attachments/assets/2058eb0b-1582-439b-9f69-1fb423d9071d)

### refreshToken 재발급 후(쿠키)

![리프레시 토큰 재발급 후 쿠키](https://github.com/user-attachments/assets/200a1cb4-1c12-48d5-aab7-7779e4927b4a)

### refreshToken 재발급 후(레디스)

![리프레시 토큰 재발급 후 레디스](https://github.com/user-attachments/assets/9aafa550-057e-4d80-8c53-589634c59c99)

### refreshToken 재발급 실패(refreshToken 만료)

![리프레시 토큰 재발급 실패-레디스에 없을 경우](https://github.com/user-attachments/assets/997c04fc-ba73-4529-be31-d01f664315ba)

## ⭐️ To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
- 